### PR TITLE
Skill Action Dialog refactor and fixes

### DIFF
--- a/PF2e/Contributions by others/Skill Action Dialog.js
+++ b/PF2e/Contributions by others/Skill Action Dialog.js
@@ -320,7 +320,12 @@ function earnIncome() {
 
 function unspecifiedActivity(skillName, secret = false) {
   let _title = skillName.charAt(0).toUpperCase() + skillName.slice(1) + " Check"; // uppercase first letter
-  const _skill = actor.skills[skillName];
+  let _skill;
+  if (skillName == "perception") {
+    _skill = actor.perception;
+  } else {
+    _skill = actor.skills[skillName];
+  }
   let checkData = {
     actor,
     type: "skill-check",
@@ -328,7 +333,7 @@ function unspecifiedActivity(skillName, secret = false) {
   }
   if (secret) {
     checkData["options"] = ["secret"];
-}
+  }
   game.pf2e.Check.roll(new game.pf2e.CheckModifier(_title, _skill), checkData);
 }
 


### PR DESCRIPTION
- handles automatic detection of token (selecting a token overrides automatic detection)
- stops using deprecated data system structures
- replaces `uncodedSkill()` with `unspecifiedActivity()` which is DRY/simplified
- use system-provided actions wherever possible at this time (use `coreAction()` before `unspecifiedActivity()`)
- add support for generic, non-specific checks using skills (same as going to the sheet and clicking on the modifier for a skill)
- correctly filter Lore skills, regardless of naming convention (exception: if a player names a lore skill the same as a core skill)
- lots of formatting fixes
