### PR TITLE
Add support for Terrifying Transformation to Demoralize macro

### DIFF
--- a/PF2e/Contributions by others/Demoralize.js
+++ b/PF2e/Contributions by others/Demoralize.js
@@ -96,7 +96,7 @@ function createContent(){
 }
 
 // Ignoring Reach for the Sky / Tut-Tu / Beast Dynamo Howl / Deimatic Display as they use a single check for all targets
-const multitargetFeats = ["dazzling-display", "frightening-appearance", "terrifying-howl", "flash-your-badge", "terrible-transformation", "menacing-prowess"];
+const multitargetFeats = ["dazzling-display", "frightening-appearance", "terrifying-howl", "flash-your-badge", "terrible-transformation", "menacing-prowess", "terrifying-transformation"];
 const demoralizeMultitarget = token.actor.items.find(item => multitargetFeats.includes(item.slug));
 
 if (game.user.targets.size == 0){


### PR DESCRIPTION
This adds werecreature archetype's [Terrifying Transformation](https://2e.aonprd.com/Feats.aspx?ID=5501) feat as an option for multi-target demoralize feats.

